### PR TITLE
게시물 삭제처리

### DIFF
--- a/src/main/java/com/aqours_challenge/our_challenge/config/SecurityConfig.java
+++ b/src/main/java/com/aqours_challenge/our_challenge/config/SecurityConfig.java
@@ -21,7 +21,7 @@ public class SecurityConfig {
     @Bean
     protected SecurityFilterChain webSecurityFilterChain(HttpSecurity http) throws Exception {
         http.authorizeHttpRequests((auth) -> auth
-                .requestMatchers("/","/css/**", "/members/**").permitAll()
+                .requestMatchers("/","/error","/css/**", "/members/**").permitAll()
                 .requestMatchers("/images/**").permitAll()
                 .requestMatchers("/admin/**").hasRole("ADMIN")
                 .requestMatchers("/posts/**","/mypage/**").hasAnyRole("USER", "ADMIN","STAFF")

--- a/src/main/java/com/aqours_challenge/our_challenge/controller/PostController.java
+++ b/src/main/java/com/aqours_challenge/our_challenge/controller/PostController.java
@@ -6,17 +6,17 @@ import com.aqours_challenge.our_challenge.entity.Post;
 import com.aqours_challenge.our_challenge.service.MemberService;
 import com.aqours_challenge.our_challenge.service.PostService;
 import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.validation.BindingResult;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.*;
 
 import java.security.Principal;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 
 @Controller
@@ -34,7 +34,7 @@ public class PostController {
     public String getPosts(Model model) {
         // 게시물 리스트 전달
         List<Post> postList = new ArrayList<>();
-        postList = postService.getAllPosts();
+        postList = postService.getAllPostNotDeleted();
 
         model.addAttribute("postList", postList);
 
@@ -78,9 +78,35 @@ public class PostController {
     public String detailPost(@PathVariable String strPostId, Model model, Principal principal) {
         Long postId = Long.parseLong(strPostId);
         Post post = postService.getPostByPostId(postId);
+        if (!post.getDeleteFlag().equals("N")) {
+            return "customError/deleted-post";
+        }
         String memberName = memberService.findMemberByEmail(principal.getName()).getMemberName();
         model.addAttribute("post", post);
         model.addAttribute("memberName", memberName);
         return "post/detail-post";
     }
+
+//    @DeleteMapping
+//    public ResponseEntity<Map<String, Object>> deletePost(@RequestBody HashMap<String, Object> params) {
+//        Map<String, Object> result = new HashMap<>();
+//
+//        result.put("message", "게시물 삭제 처리");
+//        if (params == null || params.isEmpty() || params.get("postId") == null) {
+//            result.put("error", "Invalid parameters");
+//            return ResponseEntity.badRequest().body(result);
+//        }
+//
+//        int resultQuery = postService.deletePost(params.get("postId").toString());
+//
+//        if (resultQuery == 0) {
+//            result.put("error", "Post not found");
+//            return ResponseEntity.badRequest().body(result);
+//        }
+//
+//        result.put("status", resultQuery + "개의 게시물 삭제완료");
+//        return ResponseEntity
+//                .ok()
+//                .body(result);
+//    }
 }

--- a/src/main/java/com/aqours_challenge/our_challenge/controller/PostRestController.java
+++ b/src/main/java/com/aqours_challenge/our_challenge/controller/PostRestController.java
@@ -1,4 +1,42 @@
 package com.aqours_challenge.our_challenge.controller;
 
+import com.aqours_challenge.our_challenge.service.PostService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@RestController
 public class PostRestController {
+    private final PostService postService;
+
+    public PostRestController(PostService postService) {
+        this.postService = postService;
+    }
+
+    @PostMapping(value = "/api/posts", produces = "application/json; charset=UTF-8")
+    public ResponseEntity<Map<String, Object>> deletePost(@RequestBody Map<String, Object> params) {
+        Map<String, Object> result = new HashMap<>();
+
+//        String postId = "2";
+        result.put("message", "게시물 삭제 처리");
+        if (params == null || params.isEmpty() || params.get("postId") == null) {
+//        if (postId == null || postId.isEmpty()) {
+            result.put("error", "Invalid parameters");
+            return ResponseEntity.badRequest().body(result);
+        }
+
+        int resultQuery = postService.deletePost(params.get("postId").toString());
+
+        if (resultQuery == 0) {
+            result.put("error", "Post not found");
+            return ResponseEntity.badRequest().body(result);
+        }
+
+        result.put("status", resultQuery + "개의 게시물 삭제완료");
+        return ResponseEntity
+                .ok()
+                .body(result);
+    }
 }

--- a/src/main/java/com/aqours_challenge/our_challenge/repository/PostRepository.java
+++ b/src/main/java/com/aqours_challenge/our_challenge/repository/PostRepository.java
@@ -2,13 +2,27 @@ package com.aqours_challenge.our_challenge.repository;
 
 import com.aqours_challenge.our_challenge.entity.Post;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
 public interface PostRepository extends JpaRepository<Post, Long> {
     Post findByPostId(Long postId);
+
+    @Query("select p from Post p " +
+            "where p.deleteFlag = 'N' " +
+            "order by p.postId asc")
+    List<Post> getAllPostNotDeleted();
+
+    @Modifying
+    @Transactional
+    @Query("update Post p " +
+            "set p.deleteFlag = 'Y' " +
+            "where p.postId = :postId")
+    int deletePost(@Param("postId") Long postId);
 
     @Query("select p from Post p " +
             "where p.title like %:keyword% " +

--- a/src/main/java/com/aqours_challenge/our_challenge/service/PostService.java
+++ b/src/main/java/com/aqours_challenge/our_challenge/service/PostService.java
@@ -14,8 +14,8 @@ public class PostService {
         this.postRepository = postRepository;
     }
 
-    public List<Post> getAllPosts() {
-        return postRepository.findAll();
+    public List<Post> getAllPostNotDeleted() {
+        return postRepository.getAllPostNotDeleted();
     }
 
     public Post savePost(Post post) {
@@ -23,6 +23,10 @@ public class PostService {
             throw new IllegalStateException("동일한 게시물을 작성할 수 없습니다.");
         }
         return postRepository.save(post);
+    }
+
+    public int deletePost(String postId) {
+        return postRepository.deletePost(Long.parseLong(postId));
     }
 
     public boolean isDoubledRequest(Post post) {

--- a/src/main/resources/templates/customError/deleted-post.html
+++ b/src/main/resources/templates/customError/deleted-post.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Title</title>
+</head>
+<body>
+   삭제된 게시물입니다.
+  <button onclick="location.href='/';">홈으로</button>
+  <button onclick="location.href='/posts/search';">목록</button>
+</body>
+</html>

--- a/src/main/resources/templates/post/detail-post.html
+++ b/src/main/resources/templates/post/detail-post.html
@@ -3,6 +3,10 @@
       xmlns:th="http://www.thymeleaf.org"
       xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
       layout:decorate="~{layouts/layout1}">
+<head>
+    <!-- jQuery CDN 추가 -->
+    <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+</head>
 <!-- 사용자 css 추가 -->
 <th:block layout:fragment="css">
     <style>
@@ -49,4 +53,45 @@
             <div th:text="${post.getTags()}"></div>
         </li>
     </ul>
+    <button onclick="deletePost()">삭제</button>
+    <input type="hidden" class="post-id" th:value="${post.getPostId()}">
+
+    <meta name="_csrf" th:content="${_csrf.token}"/>
+    <meta name="_csrf_header" th:content="${_csrf.headerName}"/>
+<!--    <meta name="_csrf" th:content="${_csrf.token}">  &lt;!&ndash; meta 태그로 CSRF 토큰 삽입 &ndash;&gt;-->
 </div>
+<script>
+    function deletePost() {
+        // CSRF 토큰을 meta 태그에서 가져옴
+        var csrfToken = $('meta[name="_csrf"]').attr('content');  // meta 태그에서 CSRF 토큰을 가져옴
+        var csrfHeader = $('meta[name="_csrf_header"]').attr('content');  // CSRF 헤더 이름 가져오기
+
+        var postId = document.querySelector(".post-id").value;
+
+        $.ajax({
+            url: "/api/posts",
+            type: "POST",
+            data: JSON.stringify({
+                postId: postId,
+            }),
+            contentType:"application/json",
+            beforeSend: function(xhr) {
+                // CSRF 토큰을 헤더에 추가
+                xhr.setRequestHeader(csrfHeader, csrfToken);
+            },
+            success: function (data, status, xhr) {
+                if (status === 200) {
+                    alert(data.status);
+                    document.location.replace("/posts/search");
+                }
+                return;
+            },
+            error: function(data, status, err) {
+                console.error(err);
+                alert("error!");
+                return;
+            }
+        })
+    }
+</script>
+</html>


### PR DESCRIPTION
개요
> 작성된 게시물을 삭제처리하는 기능을 구현한다. 이는 DB상의 데이터를 완전히 삭제하는 것이 아닌, 삭제여부를 결정하는 deleteFlag 값을 수정하여 게시물 목록 등을 가져올때 제외시키는 방식으로 구현한다. 이로 인해 데이터는 남겨둔채로 사용자 입장에서는 삭제된것처럼 인식하게 된다.

작업내용
> - 게시물 상세페이지에서 게시물 삭제버튼 구현
> - ajax 요청을 보내 게시물 삭제가 진행되며, 응답에 따라 글 목록으로 리다이렉트된다
> - 삭제된 게시물에 대한 url 접근시 별도로 작성한 에러페이지로 이동하게 된다

문제해결
> 계속해서 403오류가 발생하였는데, 이는 어떠한 이유로 서버로의 접근이 거부된 것이다. 알아보니 스프링부트에서 ajax요청을 사용할 경우 csrf토큰을 요청헤더에 포함시켜주어야 했다. 
> csrf 인증문제를 해결하고 나니 이번에는 리포지토리에서 쿼리수행 과정에 문제가 발생하였다. update, delete 쿼리의 경우 @Modifying 어노테이션이 필요하였다. 어노테이션 적용 후. 정상적으로 동작하였다.
<img width="410" alt="스크린샷 2025-03-28 오전 12 15 05" src="https://github.com/user-attachments/assets/a6a5b89f-78ca-4fd7-814c-dd177cdadd4b" />
