### PR TITLE
41-Redis사용에 따른 쿠키명 고정 필요

### DIFF
--- a/src/main/java/com/aqours_challenge/our_challenge/config/SessionConfig.java
+++ b/src/main/java/com/aqours_challenge/our_challenge/config/SessionConfig.java
@@ -1,0 +1,19 @@
+package com.aqours_challenge.our_challenge.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.session.web.http.CookieSerializer;
+import org.springframework.session.web.http.DefaultCookieSerializer;
+
+@Configuration
+public class SessionConfig {
+
+    @Bean
+    public CookieSerializer cookieSerializer() {
+        DefaultCookieSerializer serializer = new DefaultCookieSerializer();
+        serializer.setCookieName("JSESSIONID"); // ✅ .jvmRoute 제거
+        serializer.setUseHttpOnlyCookie(true);
+        serializer.setUseSecureCookie(false); // HTTPS가 아니라면 false
+        return serializer;
+    }
+}


### PR DESCRIPTION
- Redis 사용으로 인해 쿠키명이 JSESSIONID.2a8c34b4 으로 나타나고 있어 혼동이 발생